### PR TITLE
Attempt to remove flakiness from test

### DIFF
--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/salsa/SalsaTest.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/salsa/SalsaTest.java
@@ -267,15 +267,21 @@ public class SalsaTest {
             .build();
 
     sourceIdList.clear();
-    for (int i = 1; i <= maxNumLeftNodes; i++) {
+    for (int i = 1; i <= 2*maxNumLeftNodes; i++) {   //number of iterations increased to account for repitition in random number generation
       sourceIdList.add((long) random.nextInt(maxUserId));
+      if (sourceIdList.size()==maxNumLeftNodes){    //ensures that size of sourceIdList is as intended
+        break;
+      }
     }
     sourceIdList.add(userId);
 
     for (long sourceId : sourceIdList) {
       destinationIds.clear();
-      for (int i = 1; i <= leftDegree; i++) {
+      for (int i = 1; i <= 2*leftDegree; i++) {   //number of iterations increased to account for repitition in random number generation
         destinationIds.add((long) random.nextInt(maxUserId));
+        if (destinationIds.size()==leftDegree){  //ensures that size of destinationIdList is as intended
+          break;
+        }
       }
       for (long destinationId : destinationIds) {
         smallLeftRegularBipartiteGraph.addEdge(sourceId, destinationId, (byte) 0);
@@ -289,7 +295,6 @@ public class SalsaTest {
     SalsaResponse salsaResponse = salsa.computeRecommendations(salsaRequest, random);
     List<RecommendationInfo> salsaResults =
         Lists.newArrayList(salsaResponse.getRankedRecommendations());
-
     assertEquals(expectedSalsaStats, salsaResponse.getSalsaStats());
     assertEquals(expectedTopResults, salsaResults);
   }

--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/salsa/SalsaTest.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/salsa/SalsaTest.java
@@ -295,6 +295,7 @@ public class SalsaTest {
     SalsaResponse salsaResponse = salsa.computeRecommendations(salsaRequest, random);
     List<RecommendationInfo> salsaResults =
         Lists.newArrayList(salsaResponse.getRankedRecommendations());
+        
     assertEquals(expectedSalsaStats, salsaResponse.getSalsaStats());
     assertEquals(expectedTopResults, salsaResults);
   }


### PR DESCRIPTION
### Flaky test
com.twitter.graphjet.algorithms.salsa.SalsaTest.testSalsaWithRandomGraph
### What is the test meant for?
The test is meant for testing the SALSA algorithm on a random bipartite graph. 
### What causes flakiness in this test?
In Lines 270 - 278, a random bipartite graph is being generated. Hash sets are being used to store nodes. Nodes in this context are, randomly generated User-ID's (upto 'maxUserId' in this case). The graph is intended to have 'maxNumLeftNodes' number of nodes on the left, each having a degree of 'leftDegree'.  There's a finite chance that the random integer generator might give equal integers and as Hash Sets only store unique values, the number of nodes created could be less than intended. The change I have made, removes this non-determinism from the test. 
### How is the flakiness corrected?
Increase the number of random UserId generating iterations and break the loop when the size of Hash Set (containing nodes) becomes equal to the intended size.
### NonDex log before the changes

(The test passed when run normally without NonDex)

Failed tests: 
  SalsaTest.testSalsaWithRandomGraph:298 expected:<SalsaStats{numSeedNodes=1, numDirectNeighbors=64, numRightNodesReached=998, numRHSVisits=21050, minVisitsPerRightNode=1, maxVisitsPerRightNode=227, numRightNodesFiltered=64}> but was:<SalsaStats{numSeedNodes=1, numDirectNeighbors=63, numRightNodesReached=1000, numRHSVisits=21135, minVisitsPerRightNode=1, maxVisitsPerRightNode=223, numRightNodesFiltered=63}>

Failed tests: 
  SalsaTest.testSalsaWithRandomGraph:298 expected:<SalsaStats{numSeedNodes=1, numDirectNeighbors=64, numRightNodesReached=998, numRHSVisits=21050, minVisitsPerRightNode=1, maxVisitsPerRightNode=227, numRightNodesFiltered=64}> but was:<SalsaStats{numSeedNodes=1, numDirectNeighbors=63, numRightNodesReached=1000, numRHSVisits=21184, minVisitsPerRightNode=1, maxVisitsPerRightNode=232, numRightNodesFiltered=63}>

Failed tests: 
  SalsaTest.testSalsaWithRandomGraph:298 expected:<SalsaStats{numSeedNodes=1, numDirectNeighbors=64, numRightNodesReached=998, numRHSVisits=21050, minVisitsPerRightNode=1, maxVisitsPerRightNode=227, numRightNodesFiltered=64}> but was:<SalsaStats{numSeedNodes=1, numDirectNeighbors=63, numRightNodesReached=998, numRHSVisits=21097, minVisitsPerRightNode=1, maxVisitsPerRightNode=230, numRightNodesFiltered=63}>

Failed tests: 
  SalsaTest.testSalsaWithRandomGraph:293 expected:<SalsaStats{numSeedNodes=1, numDirectNeighbors=64, numRightNodesReached=998, numRHSVisits=21050, minVisitsPerRightNode=1, maxVisitsPerRightNode=227, numRightNodesFiltered=64}> but was:<SalsaStats{numSeedNodes=1, numDirectNeighbors=62, numRightNodesReached=997, numRHSVisits=21174, minVisitsPerRightNode=1, maxVisitsPerRightNode=233, numRightNodesFiltered=62}>

Failed tests: 
  SalsaTest.testSalsaWithRandomGraph:293 expected:<SalsaStats{numSeedNodes=1, numDirectNeighbors=64, numRightNodesReached=998, numRHSVisits=21050, minVisitsPerRightNode=1, maxVisitsPerRightNode=227, numRightNodesFiltered=64}> but was:<SalsaStats{numSeedNodes=1, numDirectNeighbors=64, numRightNodesReached=998, numRHSVisits=21111, minVisitsPerRightNode=1, maxVisitsPerRightNode=232, numRightNodesFiltered=64}>

### NonDex log after changes:

(The test fails when run normally without NonDex. It seems that the test deterministically fails now.)

Failed tests: 
  SalsaTest.testSalsaWithRandomGraph:298 expected:<SalsaStats{numSeedNodes=1, numDirectNeighbors=64, numRightNodesReached=998, numRHSVisits=21050, minVisitsPerRightNode=1, maxVisitsPerRightNode=227, numRightNodesFiltered=64}> but was:<SalsaStats{numSeedNodes=1, numDirectNeighbors=64, numRightNodesReached=999, numRHSVisits=20984, minVisitsPerRightNode=1, maxVisitsPerRightNode=220, numRightNodesFiltered=64}>

Failed tests: 
  SalsaTest.testSalsaWithRandomGraph:298 expected:<SalsaStats{numSeedNodes=1, numDirectNeighbors=64, numRightNodesReached=998, numRHSVisits=21050, minVisitsPerRightNode=1, maxVisitsPerRightNode=227, numRightNodesFiltered=64}> but was:<SalsaStats{numSeedNodes=1, numDirectNeighbors=64, numRightNodesReached=1000, numRHSVisits=21146, minVisitsPerRightNode=1, maxVisitsPerRightNode=230, numRightNodesFiltered=64}>

Failed tests: 
  SalsaTest.testSalsaWithRandomGraph:298 expected:<SalsaStats{numSeedNodes=1, numDirectNeighbors=64, numRightNodesReached=998, numRHSVisits=21050, minVisitsPerRightNode=1, maxVisitsPerRightNode=227, numRightNodesFiltered=64}> but was:<SalsaStats{numSeedNodes=1, numDirectNeighbors=64, numRightNodesReached=999, numRHSVisits=21033, minVisitsPerRightNode=1, maxVisitsPerRightNode=223, numRightNodesFiltered=64}>

Failed tests: 
  SalsaTest.testSalsaWithRandomGraph:298 expected:<SalsaStats{numSeedNodes=1, numDirectNeighbors=64, numRightNodesReached=998, numRHSVisits=21050, minVisitsPerRightNode=1, maxVisitsPerRightNode=227, numRightNodesFiltered=64}> but was:<SalsaStats{numSeedNodes=1, numDirectNeighbors=64, numRightNodesReached=999, numRHSVisits=21056, minVisitsPerRightNode=1, maxVisitsPerRightNode=222, numRightNodesFiltered=64}>

### A few observations

1. Before the change, 'numDirectNeighbors' parameter took different values (62, 63, 64) in different runs of NonDex.

2. After the change, 'numDirectNeighbors' always takes the value 64 (which is, as intended).

3. The other parameters are dependent on the execution of the Salsa Algorithm. I checked out relevant portions of the implementation of the SALSA algorithm and couldn't find anything which could lead to flaky behaviour except for the fact that the algorithm itself is non-deterministic, meaning: the decision to visit a particular node is probabilistic (random number generator is used for this). I think, as NonDex affects the sequence of random numbers generated, the test parameter values would be variable when run with NonDex. This will automatically imply test-failures when run with NonDex as the test simply compares the parameter values against a fixed set of values. 

**There is a possibility that the test hasn't been designed correctly. The expected parameter values may have been wrongly determined by the programmer who developed the test, which is why the test keeps failing deterministically**